### PR TITLE
fix Cannot read property 'push' of undefined

### DIFF
--- a/jasmine-check.js
+++ b/jasmine-check.js
@@ -40,7 +40,7 @@ function checkIt(it) {
 
     function checkRunner() {
       // Intercept match results
-      var matchFailed, matchResults, failingMatchResults;
+      var matchFailed = [], matchResults = [], failingMatchResults = [];
 
       var addResult = spec.addMatcherResult ?
         spec.addMatcherResult.bind(spec) :


### PR DESCRIPTION
using jasmine-check in a jest environment throws the error:
Cannot read property 'push' of undefined

this can be fixed by initializing the variables correctly as arrays.

please merge, thx