### PR TITLE
Improve shrunk failing data output

### DIFF
--- a/jasmine-check.js
+++ b/jasmine-check.js
@@ -1,4 +1,5 @@
 var testcheck = require('testcheck');
+var javascriptStringify = require('javascript-stringify');
 var jasmine;
 var isJasmineV1;
 
@@ -121,7 +122,7 @@ function logException(e) {
 
 function printValues(values) {
   return '( ' + values.map(function (v) {
-    return JSON.stringify(v);
+    return javascriptStringify(v);
   }).join(', ') + ' )';
 }
 

--- a/jasmine-check.js
+++ b/jasmine-check.js
@@ -1,5 +1,5 @@
 var testcheck = require('testcheck');
-var javascriptStringify = require('javascript-stringify');
+var util = require('util');
 var jasmine;
 var isJasmineV1;
 
@@ -121,9 +121,7 @@ function logException(e) {
 }
 
 function printValues(values) {
-  return '( ' + values.map(function (v) {
-    return javascriptStringify(v);
-  }).join(', ') + ' )';
+  return util.inspect(values, { depth: null, colors: true });
 }
 
 exports.install = install;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "main": "jasmine-check.js",
   "dependencies": {
+    "javascript-stringify": "^1.0.1",
     "testcheck": "^0.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   },
   "main": "jasmine-check.js",
   "dependencies": {
-    "javascript-stringify": "^1.0.1",
     "testcheck": "^0.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
JSON.stringify won't correctly output data that is not of type supported by the JSON spec. This could cause misleading output, for example NaN being output as null, and functions not being listed.

You can see the corresponding issue listed for mocha-check here: https://github.com/leebyron/mocha-check/issues/2

I wasn't clear to me how to test this with Jasmine.
