### PR TITLE
Support 'fit'

### DIFF
--- a/jasmine-check.js
+++ b/jasmine-check.js
@@ -16,9 +16,9 @@ function install(globalObj) {
   check.it = checkIt(globalObj.it);
   check.xit = check.it.skip = checkIt(globalObj.xit);
 
-  var iit = globalObj.iit || globalObj.it.only;
+  var iit = globalObj.iit || globalObj.it.only || globalObj.fit;
   if (iit) {
-    check.iit = check.it.only = checkIt(globalObj.iit);
+    check.iit = check.it.only = check.fit = checkIt(iit);
   }
 
   globalObj.gen = testcheck.gen;


### PR DESCRIPTION
Hi Lee,

This adds support for `fit` as an alias of `iit` and `it.only`. It seems that `fit` is the only name now supported by `jest`, so this is needed for compatibility. I'm davemccabe@ on Messenger if you have any questions.

Thanks!
Dave
